### PR TITLE
Improve RSS import and theme style

### DIFF
--- a/wp-content/themes/dailynewsafrica-child/index.php
+++ b/wp-content/themes/dailynewsafrica-child/index.php
@@ -3,6 +3,11 @@
     <h1 class="mb-4">Daily News Africa</h1>
     <?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
         <article class="mb-5">
+            <?php if ( has_post_thumbnail() ) : ?>
+                <div class="mb-3">
+                    <?php the_post_thumbnail( 'large', [ 'class' => 'img-fluid' ] ); ?>
+                </div>
+            <?php endif; ?>
             <h2><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
             <?php the_content(); ?>
         </article>

--- a/wp-content/themes/dailynewsafrica-child/style.css
+++ b/wp-content/themes/dailynewsafrica-child/style.css
@@ -10,5 +10,27 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: dailynewsafrica
 */
 
+@font-face {
+    font-family: 'Helvetica Neue LT Std';
+    src: url('https://numero.com/wp-content/themes/understrap-child-main/src/public/fonts/HelveticaNeueLTStd-Roman.woff2') format('woff2'),
+         url('https://numero.com/wp-content/themes/understrap-child-main/src/public/fonts/HelveticaNeueLTStd-Roman.woff') format('woff');
+    font-weight: 400;
+    font-style: normal;
+    font-display: swap;
+}
+
+@font-face {
+    font-family: 'Helvetica Neue LT Std';
+    src: url('https://numero.com/wp-content/themes/understrap-child-main/src/public/fonts/HelveticaNeueLTStd-Hv.woff2') format('woff2'),
+         url('https://numero.com/wp-content/themes/understrap-child-main/src/public/fonts/HelveticaNeueLTStd-Hv.woff') format('woff');
+    font-weight: 700;
+    font-style: normal;
+    font-display: swap;
+}
+
+body {
+    font-family: 'Helvetica Neue LT Std', 'Helvetica Neue', Arial, sans-serif;
+}
+
 /* Custom styles here */
 


### PR DESCRIPTION
## Summary
- fetch featured images from RSS items when importing posts
- display post thumbnails on the homepage
- load Helvetica Neue fonts used by numero.com

## Testing
- `php -l wp-content/plugins/dna-rss-aggregator/dna-rss-aggregator.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f6762184832398d65c686a91c50d